### PR TITLE
Add embabel-agent-dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,61 +21,64 @@
         <embabel-agent.version>0.1.3-SNAPSHOT</embabel-agent.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-dependencies</artifactId>
+                <version>${embabel-agent.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Main Dependencies -->
         <dependency>
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-starter</artifactId>
-            <version>${embabel-agent.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-starter-shell</artifactId>
-            <version>${embabel-agent.version}</version>
         </dependency>
 
         <!--        <dependency>-->
         <!--            <groupId>com.embabel.agent</groupId>-->
         <!--            <artifactId>embabel-agent-rag-lucene</artifactId>-->
-        <!--            <version>${embabel-agent.version}</version>-->
         <!--        </dependency>-->
 
         <dependency>
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-starter-openai</artifactId>
-            <version>${embabel-agent.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-rag-neo</artifactId>
-            <version>${embabel-agent.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-rag-pipeline</artifactId>
-            <version>${embabel-agent.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-rag-tika</artifactId>
-            <version>${embabel-agent.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-discord</artifactId>
-            <version>${embabel-agent.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-code</artifactId>
-            <version>${embabel-agent.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This pull request updates the way dependencies are managed in the `pom.xml` file by introducing a `<dependencyManagement>` section and removing explicit version declarations from individual dependencies. This change centralizes dependency version management, making it easier to maintain and update versions consistently across the project.

**Dependency Management Improvements:**

* Added a `<dependencyManagement>` section that imports `embabel-agent-dependencies` using the `${embabel-agent.version}` property, centralizing version control for all related dependencies.

* Removed explicit `<version>` tags from individual `com.embabel.agent` dependencies in favor of inheriting the version from the new dependency management section.