### PR TITLE
Add dummy OpenAI API key to Maven workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,4 +34,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_DUMMY_KEY }} # Dummy key for testing only
         run: mvn -U -B test verify


### PR DESCRIPTION
This pull request makes a small update to the Maven workflow configuration by adding a dummy OpenAI API key for testing purposes.

* Added `OPENAI_API_KEY` environment variable with a dummy value to the `jobs:` section of `.github/workflows/maven.yml` for testing.Added a dummy OpenAI API key for testing purposes.