### PR TITLE
Startup tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ WORKDIR /workspace
 
 COPY pom.xml ./
 COPY src ./src
+COPY codegen-gradle ./codegen-gradle
+RUN chmod +x /workspace/codegen-gradle/gradlew
 
 RUN mvn -q -DskipTests package
 

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ client.activate();
 By default, this starts `neo4j` + `guide` (the Java application):
 
 ```bash
-docker compose up --build -d
+docker compose --profile java up --build -d
 ```
 
 #### Running Neo4j only (for local Java development)
@@ -445,6 +445,9 @@ docker compose down --remove-orphans
 | `NEO4J_VERSION`    | `2025.10.1-community-bullseye` | Neo4j Docker image tag                           |
 | `NEO4J_USERNAME`   | `neo4j`                        | Neo4j username                                   |
 | `NEO4J_PASSWORD`   | `brahmsian`                    | Neo4j password                                   |
+| `NEO4J_HTTP_PORT`  | 7474                           | Neo4j HTTP port                                  |
+| `NEO4J_BOLT_PORT`  | 7687                           | Neo4j Bolt port                                  |
+| `NEO4J_HTTPS_PORT` | 7473                           | Neo4j HTTPS port                                 |
 | `OPENAI_API_KEY`   | (required)                     | OpenAI API key                                   |
 | `DISCORD_TOKEN`    | (optional)                     | Discord bot token                                |
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,9 +3,9 @@ services:
     image: neo4j:${NEO4J_VERSION:-2025.10.1-community-bullseye}
     container_name: embabel-neo4j
     ports:
-      - "7474:7474"  # HTTP
-      - "7687:7687"  # Bolt
-      - "7473:7473"  # HTTPS
+      - "${NEO4J_HTTP_PORT:-7474}:7474"   # HTTP
+      - "${NEO4J_BOLT_PORT:-7687}:7687"   # Bolt
+      - "${NEO4J_HTTPS_PORT:-7473}:7473"  # HTTPS
     environment:
       - NEO4J_AUTH=${NEO4J_USERNAME:-neo4j}/${NEO4J_PASSWORD:-brahmsian}
       - NEO4J_PLUGINS=["apoc"]


### PR DESCRIPTION
Minor tweaks to get the guide running:
- Update readme to start the application with Neo4j (current readme only starts Neo4j).
- Fix issue with tests when running the Docker java app. 
- Make Neo4j ports configurable.