### PR TITLE
Codex comptability

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Within the inspector UI, connect to `http://localhost:1337/sse`.
 
 - [Claude Desktop](#claude-desktop)
 - [Claude Code](#claude-code)
+- [Codex](#codex)
 - [Cursor](#cursor)
 - [Antigravity](#antigravity)
 - [Copilot CLI](#copilot-cli)
@@ -142,6 +143,18 @@ tools.
 
 See [Claude Code Permission Modes](https://code.claude.com/docs/en/iam#permission-modes) for detailed documentation on
 how permissions work.
+
+### Codex
+
+Create or update `.codex/config.toml` and add the following MCP server entry:
+
+```toml
+[mcp_servers.embabel_guide]
+command = "npx"
+args = ["-y", "mcp-remote", "http://localhost:1337/sse", "--transport", "sse-only"]
+startup_timeout_sec = 60
+tool_timeout_sec = 120
+```
 
 ### Cursor
 

--- a/src/main/java/com/embabel/guide/mcp/McpResourceConfiguration.java
+++ b/src/main/java/com/embabel/guide/mcp/McpResourceConfiguration.java
@@ -1,0 +1,62 @@
+package com.embabel.guide.mcp;
+
+import com.embabel.agent.mcpserver.sync.McpResourcePublisher;
+import com.embabel.agent.mcpserver.sync.SyncResourceSpecificationFactory;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class McpResourceConfiguration {
+
+    private static final String ABOUT_CONTENT = """
+Embabel Guide MCP server (SSE)
+
+Purpose:
+- Exposes Embabel documentation and API references to MCP clients.
+- Primary use is answering Embabel questions using MCP tools (docs_* and API lookup tools).
+
+Endpoints:
+- SSE: http://localhost:1337/sse
+- Tools list: http://localhost:1337/mcp/tools/list
+- Resources list: http://localhost:1337/mcp/resources/list
+
+Tool naming:
+- docs_* tools search Embabel documentation content.
+- embabel_agent_* tools resolve API signatures from Embabel packages.
+
+Recommended usage for agents:
+1) Prefer docs_* tools to answer Embabel questions.
+2) Use embabel_agent_* tools to confirm class/package signatures.
+3) If unsure, query tools list to see exact available tools.
+
+Notes:
+- If running on a different port, update the SSE URL accordingly.
+- This server currently exposes MCP tools and resources (no MCP prompts).
+""";
+
+    @Bean
+    public McpResourcePublisher guideResources() {
+        return new McpResourcePublisher() {
+            @Override
+            public List<SyncResourceSpecification> resources() {
+                return List.of(
+                        SyncResourceSpecificationFactory.staticSyncResourceSpecification(
+                                "embabel://guide/about",
+                                "about",
+                                "About this MCP server and how to use it",
+                                ABOUT_CONTENT,
+                                "text/plain"
+                        )
+                );
+            }
+
+            @Override
+            public String infoString(Boolean verbose, int indent) {
+                return "Embabel Guide MCP resources";
+            }
+        };
+    }
+}


### PR DESCRIPTION
The actual MCP Server Embabel Guide exposes only tools (8).
Codex needs at least a resource exposed to use the MCP server.  

docs: add Codex setup to use mcp embabel guide
feat: add MCP about resource

<img width="1488" height="552" alt="image" src="https://github.com/user-attachments/assets/16d6b135-29a5-417b-91c7-216de232885f" />
